### PR TITLE
docs: ajouter les fichiers communautaires GitHub

### DIFF
--- a/.github/CODE_OF_CONDUCT.md
+++ b/.github/CODE_OF_CONDUCT.md
@@ -1,0 +1,37 @@
+# Code de conduite
+
+## Notre engagement
+
+Nous voulons que la participation à ce projet soit ouverte, respectueuse et accueillante.
+
+Les désaccords, les critiques et les discussions difficiles sont permis lorsqu'ils sont faits de bonne foi. Le harcèlement, les insultes, les attaques personnelles, les propos discriminatoires, l'intimidation et la divulgation d'informations privées ne sont pas acceptés.
+
+## Comportements attendus
+
+Les comportements attendus incluent :
+
+- utiliser un langage respectueux ;
+- critiquer les idées plutôt que les personnes ;
+- fournir des sources lorsque c'est pertinent ;
+- accepter les corrections lorsque des erreurs sont démontrées ;
+- contribuer de façon constructive aux issues, discussions et pull requests.
+
+## Comportements inacceptables
+
+Les comportements inacceptables incluent :
+
+- le harcèlement ou l'intimidation ;
+- les attaques personnelles ;
+- les propos racistes, sexistes, homophobes, transphobes ou autrement discriminatoires ;
+- la publication d'informations privées sans consentement ;
+- le spam, la provocation répétée ou la perturbation volontaire du projet.
+
+## Application
+
+Les mainteneurs peuvent modérer, modifier, fermer ou supprimer les issues, commentaires et pull requests qui ne respectent pas ce code de conduite.
+
+Les mainteneurs peuvent aussi demander des précisions, ralentir une discussion ou refuser une contribution si elle nuit au projet ou à ses participants.
+
+## Portée
+
+Ce code de conduite s'applique aux espaces publics du projet, notamment les issues, pull requests, discussions et contributions associées au dépôt.

--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -28,12 +28,17 @@ npm run export  # générer le répertoire dist/
 npm run watch   # surveiller les fichiers pendant le développement
 ```
 
-## Ce qui est bienvenu
+## Exemples de contributions possibles
 
-- Corrections de fautes de frappe ou d'erreurs dans le contenu
-- Améliorations d'accessibilité
-- Corrections de bugs
-- Améliorations de performance
+Les contributions utiles peuvent inclure :
+
+- corrections de fautes de frappe ou d'erreurs dans le contenu ;
+- améliorations d'accessibilité ;
+- corrections de bugs ;
+- améliorations de performance ;
+- clarification de la documentation.
+
+Les mainteneurs restent responsables de prioriser, accepter ou refuser les contributions proposées.
 
 ## Questions
 

--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -1,0 +1,40 @@
+# Contribuer au projet
+
+Merci de votre intérêt pour le projet Sceptiques du Québec !
+
+## Comment contribuer
+
+### Signaler un problème
+
+Ouvrez une [issue](https://github.com/Sceptiques-du-Quebec/sceptiques-du-quebec.github.io/issues) en décrivant :
+- Ce que vous avez observé
+- Ce que vous attendiez
+- Les étapes pour reproduire le problème (si applicable)
+
+### Proposer une modification
+
+1. Forkez le dépôt
+2. Créez une branche descriptive : `git checkout -b fix/description-courte`
+3. Faites vos modifications
+4. Vérifiez que le build fonctionne : `npm ci && npm run build && npm run export`
+5. Ouvrez une Pull Request en expliquant vos changements
+
+### Environnement de développement
+
+```bash
+npm ci          # installer les dépendances
+npm run build   # compiler JS et CSS
+npm run export  # générer le répertoire dist/
+npm run watch   # surveiller les fichiers pendant le développement
+```
+
+## Ce qui est bienvenu
+
+- Corrections de fautes de frappe ou d'erreurs dans le contenu
+- Améliorations d'accessibilité
+- Corrections de bugs
+- Améliorations de performance
+
+## Questions
+
+Pour toute question générale sur le projet, ouvrez une issue ou contactez les mainteneurs.

--- a/.github/SECURITY.md
+++ b/.github/SECURITY.md
@@ -1,0 +1,26 @@
+# Politique de sécurité
+
+## Signaler une vulnérabilité
+
+Si vous découvrez une vulnérabilité de sécurité dans ce projet, **ne créez pas d'issue publique**.
+
+Contactez les mainteneurs directement via les informations disponibles sur le profil de l'organisation GitHub : [Sceptiques-du-Quebec](https://github.com/Sceptiques-du-Quebec).
+
+### Ce qu'il faut inclure dans votre rapport
+
+- Description de la vulnérabilité
+- Étapes pour la reproduire
+- Impact potentiel
+- Suggestions de correction (si vous en avez)
+
+### Délai de réponse
+
+Nous nous efforçons de répondre dans les 7 jours ouvrables. Nous vous tiendrons informé de l'avancement.
+
+## Périmètre
+
+Ce dépôt couvre le site [sceptiquesduquebec.com](https://sceptiquesduquebec.com) et le jeu Brick BreakQueer intégré.
+
+## Divulgation responsable
+
+Nous vous demandons de nous donner un délai raisonnable pour corriger la vulnérabilité avant toute divulgation publique.

--- a/readme.md
+++ b/readme.md
@@ -84,4 +84,4 @@ Tu peux :
 
 Ce projet est sous licence MIT.
 Voir le fichier LICENSE pour plus de détails :
-[LISCENCE](https://github.com/Sceptiques-du-Quebec/sceptiques-du-quebec.github.io/blob/main/LICENSE)
+[LICENCE](https://github.com/Sceptiques-du-Quebec/sceptiques-du-quebec.github.io/blob/main/LICENSE)


### PR DESCRIPTION
Bonjour,

Je propose une petite première contribution pour rendre le dépôt plus facile à maintenir et à contribuer.

Cette PR ajoute :

- un guide de contribution ;
- un code de conduite court ;
- une politique de sécurité de base ;
- une correction mineure dans le README (`LISCENCE` → `LICENCE`).

Aucun code fonctionnel n'est modifié.

J'ai gardé la PR volontairement petite pour faciliter la révision. Si ce genre de contribution est utile, je peux ensuite proposer d'autres petites améliorations séparées.

Le texte proposé reste volontairement simple et peut évidemment être ajusté par les mainteneurs selon la manière dont vous souhaitez gérer les contributions.

Validation locale :

- `git diff --check` : OK
- fichiers modifiés : 4
- aucun artefact de build inclus

Merci !