### PR TITLE
feat: ajouter la section À propos (#6)

### DIFF
--- a/src/index.html
+++ b/src/index.html
@@ -93,6 +93,18 @@
 				</ul>
 			</div>
 		</section>
+		<section id="a-propos">
+			<div>
+				<h2>À propos</h2>
+				<p>Ce site est un projet open source. Son code, ses corrections et ses améliorations peuvent être discutés publiquement sur GitHub.</p>
+				<p>Vous pouvez y signaler un bug, proposer une amélioration ou contribuer par pull request.</p>
+				<ul>
+					<li><a target="_blank" href="https://github.com/Sceptiques-du-Quebec/sceptiques-du-quebec.github.io" rel="noopener noreferrer">Code du site</a></li>
+					<li><a target="_blank" href="https://github.com/Sceptiques-du-Quebec/brick-breaqueer" rel="noopener noreferrer">Code de Brick Breaqueer</a></li>
+					<li><a target="_blank" href="https://github.com/Sceptiques-du-Quebec/sceptiques-du-quebec.github.io/issues" rel="noopener noreferrer">Signaler un bug ou proposer une idée</a></li>
+				</ul>
+			</div>
+		</section>
 	</main>
     <footer title="Tous droits réservés © Tommy Gaudet, ###YEAR###">
         <div>


### PR DESCRIPTION
Ajoute une section "À propos" à la page principale.

## Changements

- ajout d’une section `À propos` après les ressources ;
- mention que le site est open source ;
- ajout des liens vers le code du site et Brick Breaqueer ;
- ajout du lien vers les issues pour bugs et suggestions.

## Validation

- `npm run build` : OK
- `npm run export` : OK
- `npm audit --omit=dev` : OK, 0 vulnérabilité rapportée
- `git diff --check` : OK

Aucun SCSS ajouté ; la section réutilise les styles existants.

Closes #6.